### PR TITLE
test: stub animations for jest

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import App from './App';
+import Hero from './components/Hero';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('renders Start Building button', () => {
+  const onStartBuilding = jest.fn();
+  render(<Hero onStartBuilding={onStartBuilding} />);
+  const button = screen.getByText(/Start Building/i);
+  expect(button).toBeInTheDocument();
 });

--- a/frontend/src/components/Hero.tsx
+++ b/frontend/src/components/Hero.tsx
@@ -58,7 +58,7 @@ const Hero: React.FC<HeroProps> = ({ onStartBuilding }) => {
 
     return () => {
       // Cleanup
-      ScrollTrigger.getAll().forEach(trigger => trigger.kill());
+      ScrollTrigger?.getAll?.()?.forEach(trigger => trigger.kill());
     };
   }, []);
 

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -3,3 +3,29 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Mock GSAP and ScrollTrigger for Jest tests to avoid parsing ES modules
+jest.mock('gsap', () => {
+  const timeline = () => ({
+    fromTo: jest.fn().mockReturnThis(),
+    to: jest.fn().mockReturnThis(),
+  });
+  return {
+    gsap: {
+      timeline,
+      to: jest.fn(),
+      registerPlugin: jest.fn(),
+    },
+  };
+});
+
+jest.mock('gsap/ScrollTrigger', () => ({
+  __esModule: true,
+  ScrollTrigger: { getAll: jest.fn(() => []) },
+}));
+
+// Mock lottie-react which depends on canvas APIs not implemented in JSDOM
+jest.mock('lottie-react', () => ({
+  __esModule: true,
+  default: () => null,
+}));


### PR DESCRIPTION
## Summary
- mock gsap, ScrollTrigger, and lottie-react in Jest setup to handle ES modules and canvas APIs
- simplify app test to render Hero component and verify start button
- guard Hero cleanup with optional chaining to avoid undefined errors

## Testing
- `npm test -- --watchAll=false`
- `npm run build` (frontend)
- `npm run build` (ts backend)
- `curl -s http://localhost:3001/api/projects/test123/status`
- `curl -s -X POST http://localhost:3001/api/projects -H "Content-Type: application/json" -d '{"name":"Test","type":"demo","description":"desc","userId":"user1"}'` *(fails: Connection error)*


------
https://chatgpt.com/codex/tasks/task_e_68a49a3b77348329924f097322bbda94